### PR TITLE
bugfix: webpack crashes if error happens in sweetjs compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,11 @@ module.exports = function(source) {
   this.async();
 
   var config = loaderUtils.parseQuery(this.query);
-  var current_file = loaderUtils.getRemainingRequest(this)
+  var currentFile = loaderUtils.getRemainingRequest(this)
 
   async.map(
     config.modules || [],
     function(module, callback) {
-      var _this = this;
       this.resolve(this.context, module, function(err, result) {
         if (err) {
           callback(err);
@@ -20,11 +19,11 @@ module.exports = function(source) {
         try {
           callback(null, sweet.loadNodeModule(process.cwd(), result));
         } catch (e) {
-          var err = "Sweet.js compile error: " + e.description + " in " + current_file + "(" + e.lineNumber + ":" + e.column + ")"
+          var err = "Sweet.js compile error: " + e.description + " in " + currentFile + "(" + e.lineNumber + ":" + e.column + ")"
           console.log(err)
-          _this.callback(null, "throw new Error('" + err + "')", "")
+          this.callback(null, "throw new Error('" + err + "')", "")
         }
-      });
+      }.bind(this));
     }.bind(this),
     function(err, results) {
       if (err) {
@@ -33,7 +32,7 @@ module.exports = function(source) {
       }
       config.modules = results;
       var result = sweet.compile(source, config);
-      
+
       this.cacheable && this.cacheable();
       this.callback(null, result.code, result.sourceMap);
     }.bind(this)

--- a/index.js
+++ b/index.js
@@ -6,26 +6,30 @@ module.exports = function(source) {
   this.async();
 
   var config = loaderUtils.parseQuery(this.query);
+  var current_file = loaderUtils.getRemainingRequest(this)
 
   async.map(
     config.modules || [],
     function(module, callback) {
+      var _this = this;
       this.resolve(this.context, module, function(err, result) {
-	if (err) {
-	  callback(err);
-	  return;
-	}
-	try {
-	  callback(null, sweet.loadNodeModule(process.cwd(), result));
-	} catch (e) {
-	  callback(e);
-	}
+        if (err) {
+          callback(err);
+          return;
+        }
+        try {
+          callback(null, sweet.loadNodeModule(process.cwd(), result));
+        } catch (e) {
+          var err = "Sweet.js compile error: " + e.description + " in " + current_file + "(" + e.lineNumber + ":" + e.column + ")"
+          console.log(err)
+          _this.callback(null, "throw new Error('" + err + "')", "")
+        }
       });
     }.bind(this),
     function(err, results) {
       if (err) {
-	this.callback(err);
-	return;
+        this.callback(err);
+        return;
       }
       config.modules = results;
       var result = sweet.compile(source, config);


### PR DESCRIPTION
Hi, Pete.  Thanks for useful piece of software.  I'm on my way adopting this into my project (React + hiccup throw sweetjs).  And I've faced with two problems with current implementation:
1. It crashes if there's syntactic error in a processed file. For example:
`
rclass MyView = {
    render: function() {
        hiccup [div#foo.bar.baz {some: "property", another: this.props.anothervalue} 
         [p "A child element"] "Child text"]
    };
}` will crash because of ";" and it will show the exact stack trace as in [Issue #1](https://github.com/petehunt/sweetjs-loader/issues/1). 
2. I want to see compile-time errors in my browser console.
So here's my pull request, if you will.
